### PR TITLE
Shipping and risk session extension

### DIFF
--- a/example/SantanderAuthorize.php
+++ b/example/SantanderAuthorize.php
@@ -78,6 +78,21 @@ $Invoice->getRequest()->customerAddress(
 );
 
 /**
+ * Set up customer information required for risk checks
+ */
+$Invoice->getRequest()->shippingAddress(
+    'MRS',
+    'Heidel',                  // Given name
+    'Berger-Payment',           // Family name
+    null,                     // Company Name
+    'Vagerowstr. 18',          // Shipping address street
+    'DE-BW',                   // Shipping address state
+    '69115',                   // Shipping address post code
+    'Heidelberg',              // Shipping address city
+    'DE'                       // Billing address country code
+);
+
+/**
  * Set up basket or transaction information
  */
 $Invoice->getRequest()->basketData(
@@ -97,6 +112,11 @@ $Invoice->getRequest()->b2cSecured(
     '1982-07-12', // Customer birth date
     null // Basket api id
 );
+
+/**
+ * Optionally add risk session id
+ */
+$Invoice->getRequest()->getRiskInformation()->setRiskSessionId('f1b883473dba68f655714ebe4d23bf1d');
 
 
 /**

--- a/example/SantanderAuthorize.php
+++ b/example/SantanderAuthorize.php
@@ -89,7 +89,7 @@ $Invoice->getRequest()->shippingAddress(
     'DE-BW',                   // Shipping address state
     '69115',                   // Shipping address post code
     'Heidelberg',              // Shipping address city
-    'DE'                       // Billing address country code
+    'DE'                       // Shipping address country code
 );
 
 /**

--- a/lib/AbstractMethod.php
+++ b/lib/AbstractMethod.php
@@ -20,6 +20,7 @@ use Heidelpay\PhpPaymentApi\ParameterGroups\PaymentParameterGroup;
 use Heidelpay\PhpPaymentApi\ParameterGroups\PresentationParameterGroup;
 use Heidelpay\PhpPaymentApi\ParameterGroups\RequestParameterGroup;
 use Heidelpay\PhpPaymentApi\ParameterGroups\SecurityParameterGroup;
+use Heidelpay\PhpPaymentApi\ParameterGroups\ShippingParameterGroup;
 use Heidelpay\PhpPaymentApi\ParameterGroups\TransactionParameterGroup;
 use Heidelpay\PhpPaymentApi\ParameterGroups\UserParameterGroup;
 use Heidelpay\PhpPaymentApi\ParameterGroups\RiskInformationParameterGroup;
@@ -85,6 +86,9 @@ abstract class AbstractMethod implements MethodInterface
 
     /** @var SecurityParameterGroup */
     protected $security;
+
+    /** @var ShippingParameterGroup */
+    protected $shipping;
 
     /** @var TransactionParameterGroup */
     protected $transaction;
@@ -312,6 +316,20 @@ abstract class AbstractMethod implements MethodInterface
         }
 
         return $this->security;
+    }
+
+    /**
+     * Shipping getter
+     *
+     * @return ShippingParameterGroup
+     */
+    public function getShipping()
+    {
+        if ($this->shipping === null) {
+            return $this->shipping = new ShippingParameterGroup();
+        }
+
+        return $this->shipping;
     }
 
     /**

--- a/lib/ParameterGroups/RiskInformationParameterGroup.php
+++ b/lib/ParameterGroups/RiskInformationParameterGroup.php
@@ -32,6 +32,11 @@ class RiskInformationParameterGroup extends AbstractParameterGroup
     public $customerOrderCount;
 
     /**
+     * @var string risk session id
+     */
+    public $riskSessionId;
+
+    /**
      * Guestcheckout getter
      *
      * @return bool state
@@ -59,6 +64,16 @@ class RiskInformationParameterGroup extends AbstractParameterGroup
     public function getCustomerOrderCount()
     {
         return $this->customerOrderCount;
+    }
+
+    /**
+     * risk session id getter
+     *
+     * @return string
+     */
+    public function getRiskSessionId()
+    {
+        return $this->riskSessionId;
     }
 
     /**
@@ -97,6 +112,19 @@ class RiskInformationParameterGroup extends AbstractParameterGroup
     public function setCustomerOrderCount($customerOrderCount)
     {
         $this->customerOrderCount = $customerOrderCount;
+        return $this;
+    }
+
+    /**
+     * setter for risk session id
+     *
+     * @param string $riskSessionId
+     *
+     * @return \Heidelpay\PhpPaymentApi\ParameterGroups\RiskInformationParameterGroup
+     */
+    public function setRiskSessionId($riskSessionId)
+    {
+        $this->riskSessionId = $riskSessionId;
         return $this;
     }
 }

--- a/lib/ParameterGroups/ShippingParameterGroup.php
+++ b/lib/ParameterGroups/ShippingParameterGroup.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Heidelpay\PhpPaymentApi\ParameterGroups;
+
+/**
+ * This class provides the api parameter for shipping addresses.
+ *
+ * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ * @copyright
+ *
+ * @link  http://dev.heidelpay.com/heidelpay-php-payment-api/
+ *
+ * @author  Marcus Kreusch
+ *
+ * @package heidelpay\php-payment-api\parameter-groups
+ */
+class ShippingParameterGroup extends AbstractParameterGroup
+{
+    /**
+     * ShippingAddress
+     *
+     * shipping address subgroup
+     *
+     * @var \Heidelpay\PhpPaymentApi\ParameterGroups\AddressParameterGroup
+     */
+    public $address;
+
+    /**
+     * ShippingName
+     *
+     * shipping name subgroup
+     *
+     * @var \Heidelpay\PhpPaymentApi\ParameterGroups\NameParameterGroup
+     */
+    public $name;
+
+    /**
+     * ShippingAddress getter
+     *
+     * @return \Heidelpay\PhpPaymentApi\ParameterGroups\AddressParameterGroup
+     */
+    public function getAddress()
+    {
+        if ($this->address === null) {
+            return $this->address = new AddressParameterGroup();
+        }
+
+        return $this->address;
+    }
+
+    /**
+     * ShippingName getter
+     *
+     * @return \Heidelpay\PhpPaymentApi\ParameterGroups\NameParameterGroup
+     */
+    public function getName()
+    {
+        if ($this->name === null) {
+            return $this->name = new NameParameterGroup();
+        }
+
+        return $this->name;
+    }
+
+
+    /**
+     * Setter for the shipping address
+     *
+     * @param \Heidelpay\PhpPaymentApi\ParameterGroups\AddressParameterGroup $address
+     *
+     * @return \Heidelpay\PhpPaymentApi\ParameterGroups\ShippingParameterGroup
+     */
+    public function setAddress(AddressParameterGroup $address)
+    {
+        $this->address = $address;
+        return $this;
+    }
+
+    /**
+     * Setter for the shipping name
+     *
+     * @param \Heidelpay\PhpPaymentApi\ParameterGroups\NameParameterGroup $name
+     *
+     * @return \Heidelpay\PhpPaymentApi\ParameterGroups\ShippingParameterGroup
+     */
+    public function setName(NameParameterGroup $name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -171,6 +171,45 @@ class Request extends AbstractMethod
     }
 
     /**
+     * Set shipping parameter for a request
+     *
+     * @param string $salutation     shipping address salutation MR/MRS
+     * @param string $nameGiven      shipping address given name, e.g. John
+     * @param string $nameFamily     shipping address family name, e.g. Doe
+     * @param string $nameCompany    shipping address company name, e.g. heidelpay
+     * @param string $addressStreet  shipping address street of the customer, e.g. Vagerowstr.
+     * @param string $addressState   shipping address state ot the customer, e.g. Bayern
+     * @param string $addressZip     shipping address zip code, e.g. 69115
+     * @param string $addressCity    shipping address city, e.g. Heidelberg
+     * @param string $addressCountry shipping address country code 2 letters, e.g. DE
+     *
+     * @return \Heidelpay\PhpPaymentApi\Request
+     */
+    public function shippingAddress(
+        $salutation = null,
+        $nameGiven = null,
+        $nameFamily = null,
+        $nameCompany = null,
+        $addressStreet = null,
+        $addressState = null,
+        $addressZip = null,
+        $addressCity = null,
+        $addressCountry = null
+    ) {
+        $this->getShipping()->getName()->setSalutation($salutation);
+        $this->getShipping()->getName()->setGiven($nameGiven);
+        $this->getShipping()->getName()->setFamily($nameFamily);
+        $this->getShipping()->getName()->setCompany($nameCompany);
+        $this->getShipping()->getAddress()->setStreet($addressStreet);
+        $this->getShipping()->getAddress()->setState($addressState);
+        $this->getShipping()->getAddress()->setZip($addressZip);
+        $this->getShipping()->getAddress()->setCity($addressCity);
+        $this->getShipping()->getAddress()->setCountry($addressCountry);
+
+        return $this;
+    }
+
+    /**
      * @param string $shopperId
      * @param string $invoiceId
      * @param string $reversaltype string $reversaltype "CANCLE, RETURN or CREDIT"


### PR DESCRIPTION
This change adds functionality for the new shipping address and risk session id parameters required for Santander payments.

We would very much appreciate quick merging and release on Packagist as we need it in scheduled payment integration updates.

All changes are tested. If you need anything changed, please let me know.